### PR TITLE
Ignore beads credential key

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -2,6 +2,9 @@
 dolt/
 dolt-access.lock
 
+# Credentials
+.beads-credential-key
+
 # Runtime files
 bd.sock
 bd.sock.startlock


### PR DESCRIPTION
Add .beads-credential-key to .beads/.gitignore and include a 'Credentials' section header to prevent accidentally committing sensitive credential files.